### PR TITLE
install_github() instead of install()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # RechartsCustom
 在R中使用Echarts 3.0,简易版，仅支持折线图、柱形图、饼图、漏斗图、地图。
 
-devtools::install("xizhiming/RechartsCustom")
+```{r}
+devtools::install_github("xizhiming/RechartsCustom")
+```


### PR DESCRIPTION
`install_github()` instead of `install()`. Otherwise it would not work.

Additionally, I found an issue. When I tried to run the example you provided in manual, an error was returned

```
Error in force(x) : could not find function "unbox"
```

Have no idea why.
